### PR TITLE
Refactor: Relocate Stimmgruppenfilter to modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,50 @@
 </head>
 <body>
   <div id="app">
-    <h1>Chor Anfangstöne</h1>
+    <header class="app-header">
+      <h1>Chor Anfangstöne</h1>
+      <button id="filter-modal-trigger" class="icon-button filter-trigger-button" aria-label="Filter öffnen" aria-haspopup="dialog" title="Filtereinstellungen">
+    <svg fill="#000000" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+      width="800px" height="800px" viewBox="0 0 569.613 569.614"
+      xml:space="preserve">
+    <g>
+      <g>
+        <path d="M371.49,563.638l113.052-65.854c5.26-3.063,9.088-8.094,10.64-13.975c1.555-5.888,0.701-12.148-2.359-17.405
+          l-30.769-52.807c4.789-6.524,9.083-13.115,12.972-19.918c3.893-6.799,7.405-13.84,10.606-21.275l61.114-0.221
+          c6.086-0.021,11.915-2.464,16.202-6.781c4.287-4.32,6.687-10.165,6.665-16.255l-0.48-130.833
+          c-0.024-6.089-2.464-11.919-6.784-16.206c-4.299-4.269-10.113-6.662-16.166-6.662c-0.03,0-0.062,0-0.089,0l-61.182,0.242
+          c-6.444-14.462-14.428-28.14-23.871-40.913l30.417-53.143c6.294-11.001,2.481-25.025-8.52-31.316L369.403,5.335
+          c-5.281-3.023-11.545-3.822-17.424-2.231c-5.872,1.598-10.872,5.462-13.892,10.747L307.665,67
+          c-15.766-1.662-31.653-1.613-47.363,0.144l-30.796-52.892c-3.063-5.263-8.094-9.091-13.975-10.646
+          c-5.884-1.551-12.148-0.704-17.408,2.359L85.068,71.823c-10.949,6.38-14.657,20.429-8.28,31.38l30.765,52.831
+          c-4.761,6.484-9.048,13.076-12.953,19.899c-3.904,6.824-7.417,13.855-10.6,21.255l-61.139,0.235
+          C10.187,197.472-0.046,207.785,0,220.456L0.48,351.29c0.024,6.086,2.463,11.919,6.784,16.206
+          c4.299,4.269,10.11,6.661,16.166,6.661c0.028,0,0.058,0,0.086,0l61.203-0.229c6.432,14.452,14.413,28.131,23.868,40.915
+          l-30.413,53.141c-3.023,5.284-3.825,11.548-2.231,17.423c1.597,5.872,5.462,10.872,10.747,13.896l113.535,64.977
+          c3.596,2.056,7.513,3.032,11.38,3.032c7.962,0,15.701-4.146,19.942-11.552l30.417-53.149c15.799,1.671,31.684,1.619,47.348-0.144
+          l30.799,52.89c3.066,5.26,8.094,9.088,13.978,10.643C359.967,567.552,366.23,566.705,371.49,563.638z M341.129,465.911
+          c-4.902-8.418-14.599-12.815-24.137-10.994c-20.588,3.935-42.174,3.999-63.128,0.202c-9.572-1.735-19.184,2.741-24.015,11.181
+          l-26.748,46.745l-73.694-42.18l26.75-46.741c4.832-8.439,3.819-19.006-2.521-26.371c-13.978-16.239-24.685-34.594-31.818-54.554
+          c-3.265-9.131-11.918-15.227-21.61-15.227c-0.027,0-0.058,0-0.085,0l-53.825,0.199l-0.315-84.937l53.819-0.205
+          c9.722-0.04,18.366-6.197,21.576-15.374c3.69-10.557,7.962-20.019,13.06-28.917c5.101-8.914,11.089-17.387,18.311-25.897
+          c6.294-7.417,7.225-17.993,2.334-26.396l-27.081-46.509l73.385-42.754l27.078,46.497c4.893,8.4,14.544,12.821,24.095,11.004
+          c20.716-3.911,42.317-3.978,63.189-0.19c9.557,1.753,19.189-2.742,24.019-11.178l26.753-46.744l73.697,42.179l-26.753,46.742
+          c-4.826,8.437-3.816,19,2.521,26.368c13.956,16.221,24.669,34.587,31.842,54.59c3.271,9.119,11.919,15.202,21.604,15.202
+          c0.031,0,0.062,0,0.092,0l53.789-0.214l0.315,84.927l-53.783,0.192c-9.712,0.037-18.351,6.182-21.569,15.347
+          c-3.746,10.654-8.023,20.131-13.082,28.975c-5.064,8.847-11.067,17.338-18.356,25.958c-6.271,7.418-7.194,17.978-2.305,26.368
+          l27.078,46.472l-73.391,42.749L341.129,465.911z"/>
+        <path d="M392.531,346.458c16.472-28.773,20.746-62.24,12.047-94.232s-29.342-58.685-58.115-75.151
+          c-18.761-10.74-40.05-16.417-61.562-16.417c-44.446,0-85.762,23.944-107.822,62.485c-33.994,59.404-13.327,135.39,46.071,169.386
+          c18.764,10.737,40.052,16.411,61.564,16.411C329.158,408.943,370.475,385.001,392.531,346.458z M352.696,323.658
+          c-13.902,24.293-39.955,39.385-67.985,39.385c-13.528,0-26.934-3.58-38.764-10.349c-37.433-21.426-50.456-69.312-29.033-106.751
+          c13.905-24.291,39.958-39.385,67.987-39.385c13.528,0,26.932,3.58,38.762,10.355c18.136,10.379,31.142,27.197,36.628,47.359
+          C365.771,284.435,363.075,305.524,352.696,323.658z"/>
+      </g>
+    </g>
+    </svg>
+    <span class="sr-only">Filtereinstellungen</span>
+      </button>
+    </header>
     <p class="description">Wähle einen Anfangston zum Abspielen</p>
 
     <!-- Suchfeld -->
@@ -19,40 +62,40 @@
       <div id="search-results" class="search-results"></div>
     </div>
 
-<!-- Filter-Sektion mit Collapse-Funktionalität -->
-<div class="filter-section collapsible-section">
-    <div class="section-header" id="filter-header">
-      <h3>Stimmgruppenfilter</h3>
-      <button class="toggle-button" aria-expanded="true" aria-controls="filter-content">
-        <span class="arrow-icon">▼</span>
-        <span class="sr-only">Filter ein-/ausklappen</span>
-      </button>
-    </div>
-  
-    <div class="section-content" id="filter-content">
-      <!-- Hier kommen deine bestehenden Filter-Optionen -->
-      <div class="filter-options">
-        <!-- Bestehende Checkboxen für die Stimmgruppen -->
-        <label class="filter-option">
-          <input type="checkbox" data-voice="soprano" checked>
-          <span class="filter-label soprano">Sopran</span>
-        </label>
-        <label class="filter-option">
-          <input type="checkbox" data-voice="alto" checked>
-          <span class="filter-label alto">Alt</span>
-        </label>
-        <label class="filter-option">
-          <input type="checkbox" data-voice="tenor" checked>
-          <span class="filter-label tenor">Tenor</span>
-        </label>
-        <label class="filter-option">
-          <input type="checkbox" data-voice="bass" checked>
-          <span class="filter-label bass">Bass</span>
-        </label>
+    <!-- Filter Modal -->
+    <div id="filter-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="filter-modal-title">
+      <div class="modal-content">
+        <button id="modal-close-button" class="modal-close-button" aria-label="Filter schließen">&times;</button>
+        
+        <!-- Filter-Sektion mit Collapse-Funktionalität (jetzt im Modal) -->
+        <div id="voice-filter-collapsible" class="filter-section">
+          <div class="section-header" id="filter-header">
+            <h3 id="filter-modal-title">Stimmgruppenfilter</h3>
+          </div>
+        
+          <div class="section-content" id="filter-content">
+            <div class="filter-options">
+              <label class="filter-option">
+                <input type="checkbox" data-voice="soprano" checked>
+                <span class="filter-label soprano">Sopran</span>
+              </label>
+              <label class="filter-option">
+                <input type="checkbox" data-voice="alto" checked>
+                <span class="filter-label alto">Alt</span>
+              </label>
+              <label class="filter-option">
+                <input type="checkbox" data-voice="tenor" checked>
+                <span class="filter-label tenor">Tenor</span>
+              </label>
+              <label class="filter-option">
+                <input type="checkbox" data-voice="bass" checked>
+                <span class="filter-label bass">Bass</span>
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-
     <div id="loading">Lade Lieder...</div>
 
     <table id="song-table" class="hidden">
@@ -68,7 +111,7 @@
         <!-- Songs werden hier via JavaScript eingefügt -->
       </tbody>
     </table>
-  </div>
+  </div> <!-- This closes div#app -->
   <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ let allSongs: Song[] = [];
 
 document.addEventListener('DOMContentLoaded', () => {
   loadSongs();
+  setupFilterModal();
 });
 
 // Suchfunktionalität einrichten
@@ -119,9 +120,6 @@ function escapeRegExp(string: string): string {
 
 // Filter-Funktion einrichten
 function setupVoiceFilter(): void {
-  // Einklappbare Funktionalität hinzufügen
-  setupCollapsibleSections();
-
   // Filter-Einstellungen aus localStorage laden (falls vorhanden)
   loadFilterSettings();
 
@@ -274,53 +272,50 @@ function displaySongs(songs: Song[]): void {
   });
 }
 
-// Funktionalität für einklappbare Bereiche
-function setupCollapsibleSections(): void {
-  const collapsibleSections = document.querySelectorAll('.collapsible-section');
+// Filter Modal Funktionalität
+function setupFilterModal(): void {
+  const modal = document.getElementById('filter-modal') as HTMLElement;
+  const triggerButton = document.getElementById('filter-modal-trigger') as HTMLButtonElement;
+  const closeButton = document.getElementById('modal-close-button') as HTMLButtonElement;
 
-  collapsibleSections.forEach(section => {
-    const header = section.querySelector('.section-header');
-    const toggleButton = section.querySelector('.toggle-button');
-    const content = section.querySelector('.section-content');
+  if (!modal || !triggerButton || !closeButton) {
+    console.error('Filter modal elements not found. Modal functionality will be disabled.');
+    if (triggerButton) triggerButton.style.display = 'none'; // Hide trigger if modal is broken
+    return;
+  }
 
-    if (!header) return;
+  const openModal = () => {
+    modal.classList.remove('hidden');
+    modal.setAttribute('aria-hidden', 'false');
+    // Focus the close button or first interactive element within the modal
+    closeButton.focus();
+  };
 
-    // Lädt gespeicherten Zustand (optional)
-    const sectionId = section.id || 'filter-section';
-    const isCollapsed = localStorage.getItem(`${sectionId}-collapsed`) === 'true';
+  const closeModal = () => {
+    modal.classList.add('hidden');
+    modal.setAttribute('aria-hidden', 'true');
+    // Return focus to the button that opened the modal
+    triggerButton.focus();
+  };
 
-    // Initialen Zustand setzen
-    if (isCollapsed) {
-      section.classList.add('collapsed');
-      if (toggleButton instanceof HTMLElement) {
-        toggleButton.setAttribute('aria-expanded', 'false');
-      }
+  triggerButton.addEventListener('click', openModal);
+  closeButton.addEventListener('click', closeModal);
+
+  // Close modal if user clicks on the backdrop
+  modal.addEventListener('click', (event) => {
+    if (event.target === modal) {
+      closeModal();
     }
+  });
 
-    // Event-Listener für Klick auf Header oder Button
-    header.addEventListener('click', () => toggleSection(section));
-    if (toggleButton) {
-      toggleButton.addEventListener('click', (e) => {
-        e.stopPropagation(); // Verhindert doppeltes Auslösen
-        toggleSection(section);
-      });
+  // Close modal with Escape key
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !modal.classList.contains('hidden')) {
+      closeModal();
     }
   });
 }
 
-// Funktion zum Umschalten des Bereichs
-function toggleSection(section: Element): void {
-  const isCollapsed = section.classList.toggle('collapsed');
-  const toggleButton = section.querySelector('.toggle-button');
-  const sectionId = section.id || 'filter-section';
-
-  if (toggleButton) {
-    toggleButton.setAttribute('aria-expanded', (!isCollapsed).toString());
-  }
-
-  // Zustand speichern (optional)
-  localStorage.setItem(`${sectionId}-collapsed`, isCollapsed.toString());
-}
 
 // Hilfsfunktion zum Erstellen eines Wiedergabe-Buttons
 function createPlayButton(note: SongNote, voice: Voice, songTitle: string, subVoice: string | null = null): HTMLButtonElement {

--- a/src/style.css
+++ b/src/style.css
@@ -432,25 +432,11 @@ td:nth-child(4) .play-button.playing {
   cursor: wait;
 }
 
-
-/* Einklappbare Sektion */
-.collapsible-section {
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  margin-bottom: 20px;
-  background-color: #fff;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-}
-
+/* Styles for section headers (e.g., in the filter modal) */
 .section-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 12px 15px;
-  background-color: #f7f7f7;
-  border-radius: 8px 8px 0 0;
-  cursor: pointer;
-  user-select: none;
+  margin-bottom: 10px; /* Space between header and content */
 }
 
 .section-header h3 {
@@ -458,46 +444,6 @@ td:nth-child(4) .play-button.playing {
   font-size: 1rem;
   font-weight: 600;
   color: #333;
-}
-
-.toggle-button {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: #666;
-  font-size: 1rem;
-  display: flex;
-  align-items: center;
-  padding: 0;
-}
-
-.arrow-icon {
-  display: inline-block;
-  transition: transform 0.3s ease;
-}
-
-.section-content {
-  max-height: 300px; /* Initiale Höhe, wird animiert */
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-  padding: 15px;
-}
-
-/* Zustände für eingeklappten Bereich */
-.collapsible-section.collapsed .section-content {
-  max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  border-top: none;
-}
-
-.collapsible-section.collapsed .arrow-icon {
-  transform: rotate(-90deg);
-}
-
-.collapsible-section.collapsed .section-header {
-  border-radius: 8px;
-  border-bottom: none;
 }
 
 /* Verbesserte Stimmgruppenfilter-Styles */
@@ -545,3 +491,99 @@ td:nth-child(4) .play-button.playing {
     gap: 8px;
   }
 }
+
+/* App Header for Title and Cogwheel */
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem; /* Or your preferred spacing */
+}
+
+.app-header h1 {
+  margin: 0; /* Remove default h1 margin if needed */
+}
+
+/* Cogwheel Trigger Button */
+.filter-trigger-button {
+  background: none;
+  border: none;
+  font-size: 1.5rem; /* Adjust size as needed */
+  cursor: pointer;
+  padding: 0.5rem;
+  line-height: 1;
+}
+
+.filter-trigger-button svg {
+  width: 24px; /* Or your desired size */
+  height: 24px; /* Or your desired size */
+  vertical-align: middle; /* Helps with alignment */
+}
+
+
+.filter-trigger-button:hover {
+  opacity: 0.7;
+}
+
+/* Modal Styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent backdrop */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; /* Ensure it's on top */
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background-color: #fff; /* Or your app's background color for content */
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  position: relative;
+  max-width: 500px; /* Adjust as needed */
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-close-button {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: none;
+  border: none;
+  font-size: 1.8rem;
+  font-weight: bold;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+  color: #333; /* Adjust color as needed */
+}
+
+.modal-close-button:hover {
+  color: #000;
+}
+
+/* Ensure filter section within modal has appropriate styling */
+.modal .filter-section {
+  margin-top: 1rem; /* Add some space below the modal title/close button */
+}
+
+.modal .filter-section .section-header h3 {
+  margin-top: 0; /* Adjust if h3 inside modal needs different spacing */
+}
+
+/* .section-content within the modal doesn't need specific styles if 
+   .filter-section provides padding and .filter-options handles layout. */
+/* .modal .filter-section .section-content {} */


### PR DESCRIPTION
As we might expand on settings - and to save space - we moved the Stimmgruppenfilter into a settings modal. This is accessable via a cogwheel symbol on the top right.

The cogwheel is a svg under public domain from (https://www.svgrepo.com/svg/174697/cogwheel-outline)