### PR TITLE
add when the beat drops out

### DIFF
--- a/songs/when-the-beat-drops-out.json
+++ b/songs/when-the-beat-drops-out.json
@@ -1,0 +1,9 @@
+{
+    "title": "When The Beat Drops Out",
+    "notes": {
+        "soprano": "-",
+        "alto": {"Hoch": "E", "Tief": "C"},
+        "tenor": "G",
+        "bass": {"Hoch": "G3", "Tief": "C3"}
+      }
+}


### PR DESCRIPTION
Nicht 100% sicher, ob das sinnvoll ist, beim Bass die ansich denke ich richtigen, tieferen Töne (mit der 3 dahinter) anzugeben. Im Endeffekt singe ich ja eh nur die tieferen Töne vor, selbst wenn sie in der App z.B. als G4 erscheinen glaube ich.